### PR TITLE
changed obsolete link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Random members of the public are encouraged to participate in this process in or
 	wget 'http://www.openssl.org/source/openssl-1.0.1c.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
 	wget 'http://downloads.sourceforge.net/project/libpng/zlib/1.2.6/zlib-1.2.6.tar.gz'
-	wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.9.tar.gz'
+	wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng15/libpng-1.5.18.tar.gz'
 	wget 'http://fukuchi.org/works/qrencode/qrencode-3.2.0.tar.bz2'
 	wget 'http://downloads.sourceforge.net/project/boost/boost/1.55.0/boost_1_55_0.tar.bz2'
 	wget 'https://svn.boost.org/trac/boost/raw-attachment/ticket/7262/boost-mingw.patch'


### PR DESCRIPTION
Link to libpng-1.5.9.tar.gz is obsolete, changed valid one.
